### PR TITLE
FIX CODE SCANNING ALERT NO. 1: TIME-OF-CHECK TIME-OF-USE FILESYSTEM RACE CONDITION

### DIFF
--- a/utils/mkpkg/mkpkg.c
+++ b/utils/mkpkg/mkpkg.c
@@ -231,22 +231,18 @@ int add_file(FILE *archive, char *srcfn, char *dstfn, int *time, int prebuilt)
             perror("write");
             return 1;
         }
-        if (access(srcfn, F_OK) != 0)
+        int fd = open(srcfn, O_RDONLY);
+        if (fd == -1)
         {
-            fprintf(stderr, "Error: file %s does not exist\n", srcfn);
+            perror("Error opening file");
             return -1;
         }
 
-        if (access(srcfn, R_OK) != 0)
-        {
-            fprintf(stderr, "Error: cannot read file %s\n", srcfn);
-            return -1;
-        }
-
-        f = fopen(srcfn, "r");
+        f = fdopen(fd, "r");
         if (f == NULL)
         {
-            fprintf(stderr, "Error: cannot open file %s\n", srcfn);
+            perror("Error converting file descriptor to FILE*");
+            close(fd);
             return -1;
         }
         while ((n = fread(blk, 1, TAR_BLKSIZ, f)) > 0)

--- a/utils/mkpkg/mkpkg.c
+++ b/utils/mkpkg/mkpkg.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <utime.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include "inifile.h"
 


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/1](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/1)._

_To fix the TOCTOU race condition, we should avoid using `access` to check the file's existence and readability before opening it. Instead, we can directly attempt to open the file and handle any errors that arise. This ensures that the file we operate on is the same file we checked. We will use `open` to get a file descriptor and then use `fdopen` to get a `FILE*` stream from the file descriptor. This approach ensures that the file is not changed between the check and the use._
