### PR TITLE
FIX CODE SCANNING ALERT NO. 74: USE OF POTENTIALLY DANGEROUS FUNCTION

### DIFF
--- a/sdk/as/as.c
+++ b/sdk/as/as.c
@@ -219,10 +219,9 @@ static void define_macros_early(void)
         pp_pre_define(temp);
     }
 
-    gm_p = gmtime(&official_compile_time);
+    gm_p = gmtime_r(&official_compile_time, &gm);
     if (gm_p)
     {
-        gm = *gm_p;
 
         strftime(temp, sizeof temp, "__UTC_DATE__=\"%Y-%m-%d\"", &gm);
         pp_pre_define(temp);


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/74](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/74)._

_To fix the problem, we need to replace the call to `gmtime` with `gmtime_r`. The `gmtime_r` function requires an additional argument: a pointer to a `tm` structure where the result will be stored. This change ensures that each call to `gmtime_r` uses its own storage, preventing data races and potential overwrites._

_Specifically, we will:_
1. _Replace the call to `gmtime` with `gmtime_r`._
2. _Allocate a `tm` structure to pass to `gmtime_r`._
