### PR TITLE
FIX CODE SCANNING ALERT NO. 73: USE OF POTENTIALLY DANGEROUS FUNCTION

### DIFF
--- a/sdk/as/as.c
+++ b/sdk/as/as.c
@@ -204,10 +204,8 @@ static void define_macros_early(void)
     struct tm lt, *lt_p, gm, *gm_p;
     int64_t posix_time;
 
-    lt_p = localtime(&official_compile_time);
-    if (lt_p)
+    if (localtime_r(&official_compile_time, &lt))
     {
-        lt = *lt_p;
 
         strftime(temp, sizeof temp, "__DATE__=\"%Y-%m-%d\"", &lt);
         pp_pre_define(temp);
@@ -219,10 +217,8 @@ static void define_macros_early(void)
         pp_pre_define(temp);
     }
 
-    gm_p = gmtime(&official_compile_time);
-    if (gm_p)
+    if (gmtime_r(&official_compile_time, &gm))
     {
-        gm = *gm_p;
 
         strftime(temp, sizeof temp, "__UTC_DATE__=\"%Y-%m-%d\"", &gm);
         pp_pre_define(temp);


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/73](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/73)._

_To fix the problem, we should replace the call to `localtime` with `localtime_r`. This change ensures that the `tm` structure is managed by the application, preventing potential data races and undefined behaviour in multi-threaded contexts._
- _Replace the call to `localtime` with `localtime_r`._
- _Allocate a `tm` structure on the stack and pass it to `localtime_r` to store the result._
- _Update the code to use the stack-allocated `tm` structure._
