### PR TITLE
FIX CODE SCANNING ALERT NO. 75: USE OF POTENTIALLY DANGEROUS FUNCTION

### DIFF
--- a/sdk/cc/preproc.c
+++ b/sdk/cc/preproc.c
@@ -2940,17 +2940,17 @@ int macro_subst_tok(TokenString *tok_str, Sym **nested_list, Sym *s, struct macr
     else if (tok == TOK___DATE__ || tok == TOK___TIME__)
     {
         time_t ti;
-        struct tm *tm;
+        struct tm tm;
 
         time(&ti);
-        tm = localtime(&ti);
+        localtime_r(&ti, &tm);
         if (tok == TOK___DATE__)
         {
-            snprintf(buf, sizeof(buf), "%s %2d %d", ab_month_name[tm->tm_mon], tm->tm_mday, tm->tm_year + 1900);
+            snprintf(buf, sizeof(buf), "%s %2d %d", ab_month_name[tm.tm_mon], tm.tm_mday, tm.tm_year + 1900);
         }
         else
         {
-            snprintf(buf, sizeof(buf), "%02d:%02d:%02d", tm->tm_hour, tm->tm_min, tm->tm_sec);
+            snprintf(buf, sizeof(buf), "%02d:%02d:%02d", tm.tm_hour, tm.tm_min, tm.tm_sec);
         }
         cstrval = buf;
     add_cstr:


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/75](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/75)._

_To fix the problem, we need to replace the call to `localtime` with `localtime_r`. This change ensures that the `tm` structure is allocated by the caller, making the function thread-safe. Specifically, we will:_
1. _Declare a `struct tm` variable to hold the time information._
2. _Replace the call to `localtime` with `localtime_r`, passing the `struct tm` variable as an argument._
