### PR TITLE
FIX CODE SCANNING ALERT NO. 57: UNBOUNDED WRITE

### DIFF
--- a/utils/dfs/mkdfs.c
+++ b/utils/dfs/mkdfs.c
@@ -327,20 +327,20 @@ void transfer_files(char *dstdir, char *srcdir)
     char srcfn[255];
     char dstfn[255];
 
-    strcpy(srcfn, srcdir);
-    strcat(srcfn, "\\*");
+    strncpy(srcfn, srcdir, sizeof(srcfn) - 1);
+    strncat(srcfn, "\\*", sizeof(srcfn) - strlen(srcfn) - 1);
 
     hfind = FindFirstFile(srcfn, &finddata);
     more = hfind != INVALID_HANDLE_VALUE;
     while (more)
     {
-        strcpy(srcfn, srcdir);
-        strcat(srcfn, "\\");
-        strcat(srcfn, finddata.cFileName);
+        strncpy(srcfn, srcdir, sizeof(srcfn) - 1);
+        strncat(srcfn, "\\", sizeof(srcfn) - strlen(srcfn) - 1);
+        strncat(srcfn, finddata.cFileName, sizeof(srcfn) - strlen(srcfn) - 1);
 
-        strcpy(dstfn, dstdir);
-        strcat(dstfn, "/");
-        strcat(dstfn, finddata.cFileName);
+        strncpy(dstfn, dstdir, sizeof(dstfn) - 1);
+        strncat(dstfn, "/", sizeof(dstfn) - strlen(dstfn) - 1);
+        strncat(dstfn, finddata.cFileName, sizeof(dstfn) - strlen(dstfn) - 1);
 
         if (finddata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
@@ -371,13 +371,13 @@ void transfer_files(char *dstdir, char *srcdir)
         return;
     while ((dp = readdir(dir)) != NULL)
     {
-        strcpy(srcfn, srcdir);
-        strcat(srcfn, "/");
-        strcat(srcfn, dp->d_name);
+        strncpy(srcfn, srcdir, sizeof(srcfn) - 1);
+        strncat(srcfn, "/", sizeof(srcfn) - strlen(srcfn) - 1);
+        strncat(srcfn, dp->d_name, sizeof(srcfn) - strlen(srcfn) - 1);
 
-        strcpy(dstfn, dstdir);
-        strcat(dstfn, "/");
-        strcat(dstfn, dp->d_name);
+        strncpy(dstfn, dstdir, sizeof(dstfn) - 1);
+        strncat(dstfn, "/", sizeof(dstfn) - strlen(dstfn) - 1);
+        strncat(dstfn, dp->d_name, sizeof(dstfn) - strlen(dstfn) - 1);
 
         if (isdir(srcfn))
         {


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/57](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/57)._

_To fix the problem, we need to replace the `strcpy` and `strcat` functions with their safer alternatives, `strncpy` and `strncat`, which allow us to specify the maximum number of characters to copy. This will prevent buffer overflow by ensuring that the destination buffers are not overrun._
- _Replace `strcpy` with `strncpy`, specifying the size of the destination buffer minus one to leave space for the null terminator._
- _Replace `strcat` with `strncat`, specifying the remaining space in the destination buffer to ensure it does not overflow._
