### PR TITLE
Fix code scanning alert no. 80: Uncontrolled data used in path expression

### DIFF
--- a/utils/dfs/mkdfs.c
+++ b/utils/dfs/mkdfs.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -37,6 +38,15 @@
 #define S_IFMT _S_IFMT
 #define S_IFDIR _S_IFDIR
 #endif
+
+bool validate_path(const char *path)
+{
+    if (strstr(path, "..") || strchr(path, '/') || strchr(path, '\\'))
+    {
+        return false;
+    }
+    return true;
+}
 
 extern struct fs *mountlist;
 
@@ -449,13 +459,20 @@ void process_filelist(FILE *f)
         }
         else
         {
-            if (isdir(src))
+            if (validate_path(src))
             {
-                make_directory(dst);
-                transfer_files(dst, src);
+                if (isdir(src))
+                {
+                    make_directory(dst);
+                    transfer_files(dst, src);
+                }
+                else
+                    transfer_file(dst, src);
             }
             else
-                transfer_file(dst, src);
+            {
+                fprintf(stderr, "Invalid path: %s\n", src);
+            }
         }
     }
 }


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/80](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/80)._

_To fix the problem, we need to validate the user input before using it to construct file paths. Specifically, we should ensure that the `src` variable does not contain any path traversal sequences or invalid characters. We can achieve this by checking for the presence of "..", "/", or "\\" in the `src` variable and rejecting the input if any are found._
1. _Add a validation function to check for invalid sequences in the user input._
2. _Use this validation function to validate the `src` variable before using it in file operations._
