### PR TITLE
FIX CODE SCANNING ALERT NO. 15: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/src/utils/ar/ar.c
+++ b/src/utils/ar/ar.c
@@ -518,7 +518,7 @@ int main(int argc, char *argv[]) {
     }
 
     // Open output archive
-    fd = open(archive_filename, O_CREAT | O_TRUNC | O_WRONLY | O_BINARY, 0666);
+    fd = open(archive_filename, O_CREAT | O_TRUNC | O_WRONLY | O_BINARY, S_IWUSR | S_IRUSR);
     if (fd < 0) {
         perror(archive_filename);
         free_archive(&ar);


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/15](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/15)._

_To fix the problem, we need to change the file creation mode from `0666` to a more restrictive mode that allows only the current user to write to the file. The appropriate mode for this is `S_IWUSR | S_IRUSR`, which grants read and write permissions only to the file owner._
- _Change the file creation mode in the `open` function call on line 521 from `0666` to `S_IWUSR | S_IRUSR`._
- _Ensure that the necessary constants (`S_IWUSR` and `S_IRUSR`) are available by including the appropriate headers if they are not already included._
