### PR TITLE
FIX CODE SCANNING ALERT NO. 17: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/utils/mkpkg/mkpkg.c
+++ b/utils/mkpkg/mkpkg.c
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -120,9 +122,16 @@ static int write_pkgdb(char *dbfile, struct pkgdb *db)
     FILE *f;
     struct pkg *pkg;
 
-    f = fopen(dbfile, "w");
+    int fd = open(dbfile, O_WRONLY | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR);
+    if (fd < 0)
+    {
+        perror(dbfile);
+        return 1;
+    }
+    f = fdopen(fd, "w");
     if (!f)
     {
+        close(fd);
         perror(dbfile);
         return 1;
     }


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/17](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/17)._

_To fix the problem, we should ensure that the file is created with restrictive permissions, allowing only the current user to read and write to it. This can be achieved by using the `open` function with the `O_WRONLY | O_CREAT` flags and specifying the permissions `S_IWUSR | S_IRUSR`. After obtaining the file descriptor, we can use `fdopen` to get a `FILE *` stream pointer for writing to the file._
