### PR TITLE
FIX CODE SCANNING ALERT NO. 32: UNCONTROLLED DATA USED IN PATH EXPRESSION

### DIFF
--- a/utils/mkpkg/mkpkg.c
+++ b/utils/mkpkg/mkpkg.c
@@ -387,6 +387,13 @@ int make_package(struct pkgdb *db, char *inffn)
     return 0;
 }
 
+int is_valid_filename(const char *filename) {
+    if (strstr(filename, "..") || strchr(filename, '/') || strchr(filename, '\\')) {
+        return 0;
+    }
+    return 1;
+}
+
 int main(int argc, char *argv[])
 {
     int i;
@@ -415,6 +422,10 @@ int main(int argc, char *argv[])
 
     for (i = 3; i < argc; i++)
     {
+        if (!is_valid_filename(argv[i])) {
+            fprintf(stderr, "Invalid filename: %s\n", argv[i]);
+            return 1;
+        }
         // printf("Generating package %s\n", argv[i]);
         if (make_package(&db, argv[i]) != 0)
             return 1;


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/32](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/32)._

_To fix the problem, we need to validate the user input before using it to construct a file path. Specifically, we should ensure that the input does not contain any path separators ("/" or "\\") or ".." sequences, which could allow directory traversal attacks. This can be done by adding a validation function that checks for these invalid sequences and rejecting the input if any are found._
