### PR TITLE
FIX CODE SCANNING ALERT NO. 86: UNCONTROLLED DATA USED IN PATH EXPRESSION

### DIFF
--- a/src/utils/ar/ar.c
+++ b/src/utils/ar/ar.c
@@ -477,6 +477,11 @@ int main(int argc, char *argv[]) {
         return 1;
     }
     archive_filename = argv[optind++];
+    // Validate archive_filename
+    if (strstr(archive_filename, "..") || strchr(archive_filename, '/') || strchr(archive_filename, '\\')) {
+        fprintf(stderr, "Invalid archive filename.\n");
+        return 1;
+    }
 
     // Read all the input object files
     init_archive(&ar);


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/86](https://github.com/private-collaboration-consortium/ckernel/security/code-scanning/86)._

_To fix the problem, we need to validate the `archive_filename` to ensure it does not contain any path traversal sequences or absolute paths. This can be done by checking for the presence of "..", "/", or "\\" in the filename. If any of these are found, the program should reject the input and exit with an error message._
